### PR TITLE
Use microcks-cli instead of GH Actions

### DIFF
--- a/.github/workflows/test-minikube.yaml
+++ b/.github/workflows/test-minikube.yaml
@@ -131,8 +131,10 @@ jobs:
       - name: Microcks-cli test execution
         run: |
           curl -Lo microcks-cli https://github.com/microcks/microcks-cli/releases/download/0.3.0/microcks-cli-linux-amd64 && chmod +x microcks-cli
-          ./microcks-cli test 'tackle-pathfinder:0.0.2' http://192.168.49.2/pathfinder OPEN_API_SCHEMA \
-            --microcksURL=https://microcks.192.168.49.2.nip.io/api/ --waitFor=10sec --secretName='' \
+          curl https://microcks.${{steps.getMinikubeIp.outputs.value}}.nip.io/api/keycloak/config
+          curl https://keycloak.${{steps.getMinikubeIp.outputs.value}}.nip.io//auth/realms/microcks/.well-known/openid-configuration
+          ./microcks-cli test 'tackle-pathfinder:0.0.2' http://${{steps.getMinikubeIp.outputs.value}}/pathfinder OPEN_API_SCHEMA \
+            --microcksURL=https://microcks.${{steps.getMinikubeIp.outputs.value}}.nip.io/api/ --waitFor=10sec --secretName='' \
             --keycloakClientId=microcks-serviceaccount --keycloakClientSecret=ab54d329-e435-41ae-a900-ec6b3fe15c54 \
             --insecure --verbose --operationsHeaders='{\"globals\": [ { \"name\": \"Authorization\", \"values\": \"Bearer ${{steps.getKeycloakToken.outputs.value}} \" } ] }'
 

--- a/.github/workflows/test-minikube.yaml
+++ b/.github/workflows/test-minikube.yaml
@@ -132,13 +132,8 @@ jobs:
         run: |
           curl -Lo microcks-cli https://github.com/microcks/microcks-cli/releases/download/0.3.0/microcks-cli-linux-amd64 && chmod +x microcks-cli
           curl -k https://microcks.${{steps.getMinikubeIp.outputs.value}}.nip.io/api/keycloak/config
-          curl -k https://keycloak.${{steps.getMinikubeIp.outputs.value}}.nip.io//auth/realms/microcks/.well-known/openid-configuration
+          curl -k https://keycloak.${{steps.getMinikubeIp.outputs.value}}.nip.io/auth/realms/microcks/.well-known/openid-configuration
           ./microcks-cli test 'tackle-pathfinder:0.0.2' http://${{steps.getMinikubeIp.outputs.value}}/pathfinder OPEN_API_SCHEMA \
             --microcksURL=https://microcks.${{steps.getMinikubeIp.outputs.value}}.nip.io/api/ --waitFor=10sec --secretName='' \
             --keycloakClientId=microcks-serviceaccount --keycloakClientSecret=ab54d329-e435-41ae-a900-ec6b3fe15c54 \
-            --insecure --verbose --operationsHeaders='{\"globals\": [ { \"name\": \"Authorization\", \"values\": \"Bearer ${{steps.getKeycloakToken.outputs.value}} \" } ] }'
-
-
-
-
-
+            --insecure --verbose --operationsHeaders='{"globals": [{"name":"Authorization", "values": "Bearer ${{steps.getKeycloakToken.outputs.value}}"}]}'

--- a/.github/workflows/test-minikube.yaml
+++ b/.github/workflows/test-minikube.yaml
@@ -57,6 +57,7 @@ jobs:
           set -x
           kubectl create namespace tackle
           kubectl apply -f src/test/resources/test-deployment.yaml -n tackle
+          sed 's/image: quay.io/konveyor/tackle-pathfinder:0.0.1-SNAPSHOT-native/image: quay.io/${{ github.repository_owner }}/tackle-pathfinder:0.0.1-SNAPSHOT-native/g' src/main/kubernetes/tackle-pathfinder.yaml | kubectl apply -n tackle -f -
           sed 's/imagePullPolicy: Always/imagePullPolicy: Never/g' src/main/kubernetes/tackle-pathfinder.yaml | kubectl apply -n tackle -f -
       - name: Print status on Minikube
         run : |

--- a/.github/workflows/test-minikube.yaml
+++ b/.github/workflows/test-minikube.yaml
@@ -57,8 +57,7 @@ jobs:
           set -x
           kubectl create namespace tackle
           kubectl apply -f src/test/resources/test-deployment.yaml -n tackle
-          sed 's|image: quay.io/konveyor/tackle-pathfinder:0.0.1-SNAPSHOT-native|image: quay.io/${{ github.repository_owner }}/tackle-pathfinder:0.0.1-SNAPSHOT-native|g' src/main/kubernetes/tackle-pathfinder.yaml | kubectl apply -n tackle -f -
-          sed 's/imagePullPolicy: Always/imagePullPolicy: Never/g' src/main/kubernetes/tackle-pathfinder.yaml | kubectl apply -n tackle -f -
+          sed 's|image: quay.io/konveyor/|image: quay.io/${{ github.repository_owner }}/|g; s|imagePullPolicy: Always|imagePullPolicy: Never|g' src/main/kubernetes/tackle-pathfinder.yaml | kubectl apply -n tackle -f -
       - name: Print status on Minikube
         run : |
           set -x

--- a/.github/workflows/test-minikube.yaml
+++ b/.github/workflows/test-minikube.yaml
@@ -131,8 +131,8 @@ jobs:
       - name: Microcks-cli test execution
         run: |
           curl -Lo microcks-cli https://github.com/microcks/microcks-cli/releases/download/0.3.0/microcks-cli-linux-amd64 && chmod +x microcks-cli
-          curl https://microcks.${{steps.getMinikubeIp.outputs.value}}.nip.io/api/keycloak/config
-          curl https://keycloak.${{steps.getMinikubeIp.outputs.value}}.nip.io//auth/realms/microcks/.well-known/openid-configuration
+          curl -k https://microcks.${{steps.getMinikubeIp.outputs.value}}.nip.io/api/keycloak/config
+          curl -k https://keycloak.${{steps.getMinikubeIp.outputs.value}}.nip.io//auth/realms/microcks/.well-known/openid-configuration
           ./microcks-cli test 'tackle-pathfinder:0.0.2' http://${{steps.getMinikubeIp.outputs.value}}/pathfinder OPEN_API_SCHEMA \
             --microcksURL=https://microcks.${{steps.getMinikubeIp.outputs.value}}.nip.io/api/ --waitFor=10sec --secretName='' \
             --keycloakClientId=microcks-serviceaccount --keycloakClientSecret=ab54d329-e435-41ae-a900-ec6b3fe15c54 \

--- a/.github/workflows/test-minikube.yaml
+++ b/.github/workflows/test-minikube.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - tackle-89-microcks-github-action
+  #pull_request:
+  #  branches: [ main ]
 
 jobs:
   microcks-api-validation:

--- a/.github/workflows/test-minikube.yaml
+++ b/.github/workflows/test-minikube.yaml
@@ -130,7 +130,7 @@ jobs:
           done
       - name: Microcks-cli test execution
         run: |
-          curl -Lo microcks-cli https://github.com/microcks/microcks-cli/releases/download/0.3.0/microcks-cli-linux-amd64
+          curl -Lo microcks-cli https://github.com/microcks/microcks-cli/releases/download/0.3.0/microcks-cli-linux-amd64 && chmod +x microcks-cli
           ./microcks-cli test 'tackle-pathfinder:0.0.2' http://192.168.49.2/pathfinder OPEN_API_SCHEMA \
             --microcksURL=https://microcks.192.168.49.2.nip.io/api/ --waitFor=10sec --secretName='' \
             --keycloakClientId=microcks-serviceaccount --keycloakClientSecret=ab54d329-e435-41ae-a900-ec6b3fe15c54 \

--- a/.github/workflows/test-minikube.yaml
+++ b/.github/workflows/test-minikube.yaml
@@ -1,8 +1,8 @@
 name: Tackle Pathfinder CI PR Minikube Test
 
-on:
-  pull_request:
-    branches: [ main ]
+on: [push]
+  #pull_request:
+  #  branches: [ main ]
 
 jobs:
   microcks-api-validation:

--- a/.github/workflows/test-minikube.yaml
+++ b/.github/workflows/test-minikube.yaml
@@ -1,6 +1,9 @@
 name: Tackle Pathfinder CI PR Minikube Test
 
-on: [push]
+on:
+  push:
+    branches:
+      - tackle-89-microcks-github-action
   #pull_request:
   #  branches: [ main ]
 

--- a/.github/workflows/test-minikube.yaml
+++ b/.github/workflows/test-minikube.yaml
@@ -57,7 +57,7 @@ jobs:
           set -x
           kubectl create namespace tackle
           kubectl apply -f src/test/resources/test-deployment.yaml -n tackle
-          sed 's/image: quay.io/konveyor/tackle-pathfinder:0.0.1-SNAPSHOT-native/image: quay.io/${{ github.repository_owner }}/tackle-pathfinder:0.0.1-SNAPSHOT-native/g' src/main/kubernetes/tackle-pathfinder.yaml | kubectl apply -n tackle -f -
+          sed 's|image: quay.io/konveyor/tackle-pathfinder:0.0.1-SNAPSHOT-native|image: quay.io/${{ github.repository_owner }}/tackle-pathfinder:0.0.1-SNAPSHOT-native|g' src/main/kubernetes/tackle-pathfinder.yaml | kubectl apply -n tackle -f -
           sed 's/imagePullPolicy: Always/imagePullPolicy: Never/g' src/main/kubernetes/tackle-pathfinder.yaml | kubectl apply -n tackle -f -
       - name: Print status on Minikube
         run : |

--- a/.github/workflows/test-minikube.yaml
+++ b/.github/workflows/test-minikube.yaml
@@ -125,27 +125,13 @@ jobs:
           while [[ ! "$(kubectl rollout status deployment microcks-keycloak-postgresql -n microcks)" =~ "successfully" ]]; do
             sleep 15
           done
-      - name: Microcks execution
-        uses: ./.github/actions/microcks-test-action
-        with:
-          apiNameAndVersion: 'tackle-pathfinder:0.0.2'
-          testEndpoint: "http://${{steps.getMinikubeIp.outputs.value}}/pathfinder"
-          runner: OPEN_API_SCHEMA
-          microcksURL: "https://microcks.${{steps.getMinikubeIp.outputs.value}}.nip.io/api/"
-          keycloakClientId:  microcks-serviceaccount
-          keycloakClientSecret:  ab54d329-e435-41ae-a900-ec6b3fe15c54
-          waitFor: '10sec'
-          verbose: true
-          insecure: true
-          operationsHeaders: |
-            {
-              "globals": [
-                {
-                  "name": "Authorization",
-                  "values": "Bearer ${{steps.getKeycloakToken.outputs.value}} "
-                }
-              ]
-            }
+      - name: Microcks-cli test execution
+        run: |
+          curl -Lo microcks-cli https://github.com/microcks/microcks-cli/releases/download/0.3.0/microcks-cli-linux-amd64
+          ./microcks-cli test 'tackle-pathfinder:0.0.2' http://192.168.49.2/pathfinder OPEN_API_SCHEMA \
+            --microcksURL=https://microcks.192.168.49.2.nip.io/api/ --waitFor=10sec --secretName='' \
+            --keycloakClientId=microcks-serviceaccount --keycloakClientSecret=ab54d329-e435-41ae-a900-ec6b3fe15c54 \
+            --insecure --verbose --operationsHeaders='{\"globals\": [ { \"name\": \"Authorization\", \"values\": \"Bearer ${{steps.getKeycloakToken.outputs.value}} \" } ] }'
 
 
 

--- a/.github/workflows/test-minikube.yaml
+++ b/.github/workflows/test-minikube.yaml
@@ -133,7 +133,7 @@ jobs:
           curl -Lo microcks-cli https://github.com/microcks/microcks-cli/releases/download/0.3.0/microcks-cli-linux-amd64 && chmod +x microcks-cli
           curl -k https://microcks.${{steps.getMinikubeIp.outputs.value}}.nip.io/api/keycloak/config
           curl -k https://keycloak.${{steps.getMinikubeIp.outputs.value}}.nip.io/auth/realms/microcks/.well-known/openid-configuration
-          ./microcks-cli test 'tackle-pathfinder:0.0.2' http://${{steps.getMinikubeIp.outputs.value}}/pathfinder OPEN_API_SCHEMA \
+          ./microcks-cli test 'tackle-pathfinder:0.0.1' http://${{steps.getMinikubeIp.outputs.value}}/pathfinder OPEN_API_SCHEMA \
             --microcksURL=https://microcks.${{steps.getMinikubeIp.outputs.value}}.nip.io/api/ --waitFor=10sec --secretName='' \
             --keycloakClientId=microcks-serviceaccount --keycloakClientSecret=ab54d329-e435-41ae-a900-ec6b3fe15c54 \
             --insecure --verbose --operationsHeaders='{"globals": [{"name":"Authorization", "values": "Bearer ${{steps.getKeycloakToken.outputs.value}}"}]}'

--- a/.github/workflows/test-minikube.yaml
+++ b/.github/workflows/test-minikube.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - tackle-89-microcks-github-action
-  #pull_request:
-  #  branches: [ main ]
 
 jobs:
   microcks-api-validation:


### PR DESCRIPTION
For network issues reasons, it's better to switch to microcks-cli only.

Basically, it's just replacing the reference and argument passing of the GH Action to this simple shell script:

```sh
- name: Microcks-cli test execution
        run: |
          curl -Lo microcks-cli https://github.com/microcks/microcks-cli/releases/download/0.3.0/microcks-cli-linux-amd64 && chmod +x microcks-cli
          ./microcks-cli test 'tackle-pathfinder:0.0.1' http://${{steps.getMinikubeIp.outputs.value}}/pathfinder OPEN_API_SCHEMA \
            --microcksURL=https://microcks.${{steps.getMinikubeIp.outputs.value}}.nip.io/api/ --waitFor=10sec --secretName='' \
            --keycloakClientId=microcks-serviceaccount --keycloakClientSecret=ab54d329-e435-41ae-a900-ec6b3fe15c54 \
            --insecure --verbose --operationsHeaders='{"globals": [{"name":"Authorization", "values": "Bearer ${{steps.getKeycloakToken.outputs.value}}"}]}'
```

I also had to fix 2 things:
* The docker image referenced in the deployment was `konveyor` and not current github user,
* The version of the API to test is `0.0.1` as per the OpenAPI file and not `0.0.2`